### PR TITLE
Allow skipping the version check

### DIFF
--- a/images/yourls/config-container.php
+++ b/images/yourls/config-container.php
@@ -79,6 +79,9 @@ $yourls_user_passwords = [
  ** Default is false for live site. Enable when coding or before submitting a new issue */
 define( 'YOURLS_DEBUG', filter_var(getenv('YOURLS_DEBUG'), FILTER_VALIDATE_BOOLEAN) );
 
+/** Skip version check. */
+define( 'YOURLS_NO_VERSION_CHECK', getenv('YOURLS_NO_VERSION_CHECK') === false ?: filter_var(getenv('YOURLS_NO_VERSION_CHECK'), FILTER_VALIDATE_BOOLEAN) );
+
 /*
 ** URL Shortening settings
 */


### PR DESCRIPTION
Especially in environments with no direct internet access, the version check fails inevitably and causes a noticeable delay during loading of the admin page. This change makes the value configurable and allows skipping the version check by setting the environment variable `YOURLS_NO_VERSION_CHECK` to `true`.