### PR TITLE
Hide Apache version and OS information

### DIFF
--- a/images/yourls/bin/generate-variants.sh
+++ b/images/yourls/bin/generate-variants.sh
@@ -8,7 +8,7 @@ declare -A cmd=(
 )
 
 declare -A extras=(
-	[apache]='RUN a2enmod rewrite expires'
+	[apache]='RUN a2enmod rewrite expires;\n\nRUN sed -i --follow-symlinks '\''s\/ServerSignature On\/ServerSignature Off\/'\'' \/etc\/apache2\/conf-enabled\/security.conf; \\\n    sed -i --follow-symlinks '\''s\/ServerTokens OS\/ServerTokens Prod\/'\'' \/etc\/apache2\/conf-enabled\/security.conf;'
 	[fpm]=''
 	[fpm-alpine]='RUN apk add --no-cache bash'
 )


### PR DESCRIPTION
By default, the Apache web server exposes the server version and OS information. This information might help an attacker to gain a greater understanding of the system and potentially develop attacks targeted at the specific server version. This change ensures that those sensitive information do not get exposed by setting `ServerSignature Off` and `ServerTokens Prod`.