### PR TITLE
Modify Entrypoint Script to Support Docker Secret for Admin Password

### DIFF
--- a/images/yourls/container-entrypoint.sh
+++ b/images/yourls/container-entrypoint.sh
@@ -75,11 +75,19 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		cp /usr/src/yourls/user/config-container.php user/config.php
 
 		: "${YOURLS_USER:=}"
-		: "${YOURLS_PASS:=}"
-		if [ -n "${YOURLS_USER}" ] && [ -n "${YOURLS_PASS}" ]; then
-			result=$(sed "s/  getenv_container('YOURLS_USER') => getenv_container('YOURLS_PASS'),/  \'${YOURLS_USER}\' => \'${YOURLS_PASS//&/\\&}\',/g" user/config.php)
-			echo "$result" > user/config.php
-		fi
+        : "${YOURLS_PASS:=}"
+        : "${YOURLS_PASS_FILE:=}"
+        if [ -n "${YOURLS_USER}" ] && [ -n "${YOURLS_PASS}${YOURLS_PASS_FILE}" ]; then
+            if [ -n "${YOURLS_PASS_FILE}" ]; then
+                # This should retrieve the secret contents while removing any
+                # pesky whitespace/newlines...
+                YOURLS_PASS="$(cat "$YOURLS_PASS_FILE" | tr -d '[:space:]')"
+            fi
+
+            result=$(sed "s/  getenv_container('YOURLS_USER') => getenv_container('YOURLS_PASS'),/  \'${YOURLS_USER}\' => \'${YOURLS_PASS//&/\\&}\',/g" user/config.php)
+
+            echo "$result" > user/config.php
+        fi
 
 		if [ "$uid" = '0' ]; then
 			# attempt to ensure that user/config.php is owned by the run user


### PR DESCRIPTION
## The Problem

When supplying the admin password as a Docker (Compose) secret and using the `YOURLS_PASS_FILE` environment variable to specify the path at which it is mounted in the container, automatic password hashing fails, and the following message is displayed in the admin panel:

`Could not auto-encrypt passwords. Error was: "preg_replace problem".`

It took me longer than I'd like to admit to trace it, but it appears to stem from the following part of the `container-entrypoint.sh` script:

https://github.com/YOURLS/containers/blob/da022d5cfc5a5d4aeb14a9c771872bebe5df1536/images/yourls/container-entrypoint.sh#L77-L82

It's checking if the `YOURLS_USER` and `YOURLS_PASS` environment variables are both defined, and if so, overwriting the dynamic username/password array in the config file with their static values. `YOURLS_PASS` isn't defined when a secret is used for the password, and so this whole block isn't evaluated, causing the hashing process to fail as YOURLS can't actually find a match for the plaintext password in the config file.

## The (Proposed) Fix

The relevant chunk of the entrypoint script has been modified to also check for the `YOURLS_PASS_FILE` environment variable. If filled in, the contents of the file are retrieved and set as `YOURLS_PASS`, allowing the config file to be edited as intended.